### PR TITLE
feat(token-refresh): Block main container until sidecar runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ FROM golang:alpine as build-env
 
 RUN apk --no-cache add git
 
-RUN go get -v github.com/sl1pm4t/gcp-exec-creds
+RUN CGO_ENABLED=0 go get -v github.com/sl1pm4t/gcp-exec-creds
 
 
 # Dockerfile
-FROM alpine
+FROM busybox
 
 WORKDIR /app
 
 RUN mkdir /tmp/gcloud
 COPY --from=build-env /go/bin/gcp-exec-creds /app/
 ADD script.sh /app
-ENTRYPOINT "/app/script.sh"
+ENTRYPOINT [ "/app/script.sh" ]

--- a/README.md
+++ b/README.md
@@ -31,4 +31,15 @@ Halconfig deploymentEnvironment:
       - name: token-refresh
         dockerImage: armory/gcloud-auth-helper:stable
         mountPath: /tmp/gcloud
+
+    initContainers:
+      clouddriver:
+        - name: token-refresh
+          image: busybox
+          volumeMounts:
+            - name: token-refresh
+              mountPath: /tmp/gcloud
+          command:
+            - mkfifo 
+            - /tmp/gcloud/auth_token
 ```

--- a/script.sh
+++ b/script.sh
@@ -4,13 +4,18 @@ set -uo pipefail
 
 : EXEC_CREDENTIAL_PATH ${EXEC_CREDENTIAL_PATH:=/tmp/gcloud/auth_token};
 
-if ! test -p "$EXEC_CREDENTIAL_PATH"; then
+_cleanup() { exec 3>&- ; exit 0 ; };
+for i in TERM QUIT INT HUP EXIT; do trap '_cleanup' $i; done;
+
+if ! test -e "$EXEC_CREDENTIAL_PATH"; then
   mkfifo "$EXEC_CREDENTIAL_PATH";
 fi;
 while test -p "$EXEC_CREDENTIAL_PATH"; do
-  (
-    echo "$(date): Generating token" >&2;
-    script -q -f -c /app/gcp-exec-creds;
-  ) > "$EXEC_CREDENTIAL_PATH" ;
+  exec 3>"$EXEC_CREDENTIAL_PATH";
+  rm -rf "$EXEC_CREDENTIAL_PATH" > /dev/null;
+  mkfifo "$EXEC_CREDENTIAL_PATH" > /dev/null;
+  echo "$(date): Generating token" >&2;
+  /app/gcp-exec-creds >&3;
+  exec 3>&- ;
 done;
 


### PR DESCRIPTION
In order to prevent cases in which this sidecar is image-pulled/container-initialized while the main container runs, and it doesn't restart on FileNotFound err due to handling multiple kubeconfig files (like kubesvc).

 * It can still work without an initContainer, but the issue above will persist
 * With the initContainer from the readme, the main container (eg kubesvc) will block until the sidecar responds
 * Next time the main container needs to read the token, the sidecar will be waiting to execute `/app/gcp-exec-creds` without blocking
 * Named pipefile is removed and replace to make sure the main container receives a proper EOF when expected.

